### PR TITLE
test: Add coverage for template tags in message

### DIFF
--- a/test/validateMessage.test.js
+++ b/test/validateMessage.test.js
@@ -59,6 +59,7 @@ describe('validate-commit-msg.js', function() {
       expect(m.validateMessage('revert: feat($location): something')).to.equal(VALID);
       expect(m.validateMessage('style($http): something')).to.equal(VALID);
       expect(m.validateMessage('test($resource): something')).to.equal(VALID);
+      expect(m.validateMessage('fix(build): Use of `template` tags')).to.equal(VALID);
 
       expect(errors).to.deep.equal([]);
       expect(logs).to.deep.equal([]);


### PR DESCRIPTION
Coverage to test the scenario in #97 to verify it works and will continue to work internally just in case.