### PR TITLE
Fix validate exit

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -87,14 +87,10 @@ if (process.argv.join('').indexOf('mocha') === -1) {
   var validate = function (commit) {
     if (!validateMessage(commit.message) && commit.errorLog) {
       fs.appendFileSync(commit.errorLog, commit.message + '\n');
+      process.exit(1);
+    } else {
+      process.exit(0);
     }
   };
-
-  try {
-    validate(getCommit());
-    process.exit(0);
-  } catch (err) {
-    console.error(err);
-    process.exit(1);
-  }
+  validate(getCommit());
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -73,7 +73,7 @@ describe('cli', function() {
               var result = executeCliBySource(cliSource, commitMessage);
               expect(result.stdout.toString()).to.eql('Aborting commit due to empty commit message.\n');
               expect(result.stderr.toString()).to.eql('');
-              expect(result.status).to.eql(0);
+              expect(result.status).to.eql(1);
             });
           });
         }
@@ -87,7 +87,7 @@ describe('cli', function() {
               'Please fix your commit message (and consider using http://npm.im/commitizen)\n\n'
             ].join(''));
             expect(result.stderr.toString()).to.eql('INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" !\n');
-            expect(result.status).to.eql(0);
+            expect(result.status).to.eql(1);
           });
         });
 
@@ -103,7 +103,7 @@ describe('cli', function() {
               'INVALID COMMIT MSG: "patch" is not allowed type ! ',
               'Valid types are: feat, fix, docs, style, refactor, perf, test, chore, revert, custom\n'
             ].join(''));
-            expect(result.status).to.eql(0);
+            expect(result.status).to.eql(1);
           });
         });
       });


### PR DESCRIPTION
I've noticed that with #92 (released with `2.13.0`) we introduced a bug where the CLI dosn't exit the process correctly anymore. This was due to wrapping `validate()` in a try/catch statement although neither `validate()` or `validateMessage()` actually throws.

To reproduce:
- Install `validate-commit-msg` v2.13.0
- attempt to commit locally with a non-valid msg
=> You'll see the error message on the CLI, but the commit will still happen anyway (check git log)